### PR TITLE
fix logic error when json data ”true“,json out value is "truefalse"

### DIFF
--- a/ptrconvert.go
+++ b/ptrconvert.go
@@ -34,8 +34,9 @@ func ptrBoolToBuf(v unsafe.Pointer, b *Buffer) {
 	r := *(*bool)(v)
 	if r {
 		b.Write(btrue)
+	} else {
+		b.Write(bfalse)
 	}
-	b.Write(bfalse)
 }
 
 func ptrIntToBuf(v unsafe.Pointer, b *Buffer) {


### PR DESCRIPTION
package main

import (
	"fmt"

	"github.com/bet365/jingo"
)

type MyPayload struct {
	Name string `json:"name"`
	Age  int    `json:"age"`
	ID   int    `json:"-"` // "-"" lets us ignore this field
	Flag bool   `json:"flag"`
}

var enc = jingo.NewStructEncoder(MyPayload{})

func main() {

	p1 := MyPayload{
		Name: "xuxuName2",
		Age:  11,
		ID:   11,
		Flag: true,
	}

	p2 := MyPayload{
		Name: "xuxuName2",
		Age:  11,
		ID:   11,
		Flag: false,
	}

	buf := jingo.NewBufferFromPool()
	enc.Marshal(&p1, buf) // buf = {"name":"Mr Payload","age":33}
	fmt.Println(buf)
	
	buf.Reset()
	enc.Marshal(&p2, buf) // buf = {"name":"Mr Payload","age":33}
	fmt.Println(buf)
}
outprint:

{"name":"xuxuName2","age":11,"-":11,"flag":truefalse}
{"name":"xuxuName2","age":11,"-":11,"flag":false}
