### PR TITLE
add reflect.Uintptr in unspupported type code blocks

### DIFF
--- a/structencoder.go
+++ b/structencoder.go
@@ -248,6 +248,7 @@ func (e *StructEncoder) valueInst(k reflect.Kind, instr func(func(unsafe.Pointer
 		reflect.Complex128,
 		reflect.Chan,
 		reflect.Func,
+		reflect.Uintptr,
 		reflect.UnsafePointer:
 		// no
 		panic(fmt.Sprint("unsupported type ", e.f.Type.Kind(), e.f.Name))


### PR DESCRIPTION
Add reflect.Uintptr in unspupported type code blocks in structencoder.go valueInst func.