### PR TITLE
Allow easy serialization of types such as time.Time

### DIFF
--- a/structencoder.go
+++ b/structencoder.go
@@ -130,6 +130,9 @@ func NewStructEncoder(t interface{}) *StructEncoder {
 				}
 				if data, err := e.MarshalJSON(); err == nil {
 					w.Write(data)
+				} else {
+					w.Write(null)
+					return
 				}
 			}
 

--- a/structencoder.go
+++ b/structencoder.go
@@ -8,6 +8,7 @@ package jingo
 // `.String()` stringer functionality which is somewhat out of our control.
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -104,6 +105,32 @@ func NewStructEncoder(t interface{}) *StructEncoder {
 					return
 				}
 				e.JSONEncode(w)
+			}
+
+			if e.f.Type.Kind() == reflect.Ptr {
+				e.ptrval(conv)
+			} else {
+				e.val(conv)
+			}
+			continue
+
+		// support types that implement json.Marshaler when the 'fallback' option is passed
+		case opts.Contains("fallback"):
+
+			t := reflect.ValueOf(e.t).Field(e.i).Type()
+			if e.f.Type.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+
+			conv := func(v unsafe.Pointer, w *Buffer) {
+				e, ok := reflect.NewAt(t, v).Interface().(json.Marshaler)
+				if !ok {
+					w.Write(null)
+					return
+				}
+				if data, err := e.MarshalJSON(); err == nil {
+					w.Write(data)
+				}
 			}
 
 			if e.f.Type.Kind() == reflect.Ptr {


### PR DESCRIPTION
Hi,

jingo doesn't properly serialize a struct like

```
type Sample struct {
    When time.Time `json:"time"`
}
````
it will serialize it into `{}`

Using "stringer" doesn't help either, it's not the "right" json format. "encoder" also isn't of much help because you can't define `JSONEncode(*jingo.Buffer)` on a non-local type.

And embedding time.Time into a local type and rewriting everything that accesses that type isn't a very clean solution either

But time.Time already implements the json.Marshaler interface which provides []byte. If fits rather nicely.

Do you think this is a reasonable approach? If so I'll add some tests and continue on this path..