### PR TITLE
Map Encoder support

### DIFF
--- a/jingo_test.go
+++ b/jingo_test.go
@@ -358,6 +358,96 @@ func BenchmarkSliceStdLib(b *testing.B) {
 	}
 }
 
+func TestStructEncoder_map(t *testing.T) {
+
+	type s0 struct {
+		M map[string]string `json:"m"`
+	}
+
+	v := s0{map[string]string{"aa": "1", "bb": "2", "cc": "3"}}
+	want := []byte(`{"m":{"aa":"1","bb":"2","cc":"3"}}`)
+
+	enc := NewStructEncoder(s0{})
+
+	buf := NewBufferFromPool()
+	defer buf.ReturnToPool()
+
+	enc.Marshal(&v, buf)
+
+	if !bytes.Equal(want, buf.Bytes) {
+		t.Errorf("\nwant:\n%s\ngot:\n%s\n", want, buf.Bytes)
+	}
+}
+
+func TestStructEncoder_ptrmap(t *testing.T) {
+
+	type s0 struct {
+		M *map[string]string `json:"m"`
+	}
+
+	m := map[string]string{"aa": "1", "bb": "2", "cc": "3"}
+
+	v := s0{&m}
+	want := []byte(`{"m":{"aa":"1","bb":"2","cc":"3"}}`)
+
+	enc := NewStructEncoder(s0{})
+
+	buf := NewBufferFromPool()
+	defer buf.ReturnToPool()
+
+	enc.Marshal(&v, buf)
+
+	if !bytes.Equal(want, buf.Bytes) {
+		t.Errorf("\nwant:\n%s\ngot:\n%s\n", want, buf.Bytes)
+	}
+}
+
+func TestSliceEncoder_map(t *testing.T) {
+
+	v := []map[string]string{
+		nil,
+		{"KA1": "EA1", "KA2": "EA2", "KA3": "EA3"},
+		{"KB1": "EB1", "KB2": "EB2"},
+		{},
+	}
+	want := []byte(`[null,{"KA1":"EA1","KA2":"EA2","KA3":"EA3"},{"KB1":"EB1","KB2":"EB2"},{}]`)
+
+	enc := NewSliceEncoder([]map[string]string{})
+
+	buf := NewBufferFromPool()
+	defer buf.ReturnToPool()
+
+	enc.Marshal(&v, buf)
+
+	if !bytes.Equal(want, buf.Bytes) {
+		t.Errorf("\nwant:\n%s\ngot:\n%s\n", want, buf.Bytes)
+	}
+}
+
+func TestSliceEncoder_ptrmap(t *testing.T) {
+
+	m1 := map[string]string{"KA1": "EA1", "KA2": "EA2", "KA3": "EA3"}
+	m2 := map[string]string{"KB1": "EB1", "KB2": "EB2"}
+	v := []*map[string]string{
+		nil,
+		&m1,
+		&m2,
+		{},
+	}
+	want := []byte(`[null,{"KA1":"EA1","KA2":"EA2","KA3":"EA3"},{"KB1":"EB1","KB2":"EB2"},{}]`)
+
+	enc := NewSliceEncoder([]*map[string]string{})
+
+	buf := NewBufferFromPool()
+	defer buf.ReturnToPool()
+
+	enc.Marshal(&v, buf)
+
+	if !bytes.Equal(want, buf.Bytes) {
+		t.Errorf("\nwant:\n%s\ngot:\n%s\n", want, buf.Bytes)
+	}
+}
+
 // var fakeType = SmallPayload{}
 // var fake = NewSmallPayload()
 

--- a/jingo_test.go
+++ b/jingo_test.go
@@ -367,7 +367,9 @@ func TestStructEncoder_map(t *testing.T) {
 	v := s0{map[string]string{"aa": "1", "bb": "2", "cc": "3"}}
 	want := []byte(`{"m":{"aa":"1","bb":"2","cc":"3"}}`)
 
-	enc := NewStructEncoder(s0{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewStructEncoderWithConfig(s0{}, cfg)
 
 	buf := NewBufferFromPool()
 	defer buf.ReturnToPool()
@@ -390,7 +392,9 @@ func TestStructEncoder_ptrmap(t *testing.T) {
 	v := s0{&m}
 	want := []byte(`{"m":{"aa":"1","bb":"2","cc":"3"}}`)
 
-	enc := NewStructEncoder(s0{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewStructEncoderWithConfig(s0{}, cfg)
 
 	buf := NewBufferFromPool()
 	defer buf.ReturnToPool()
@@ -412,7 +416,9 @@ func TestSliceEncoder_map(t *testing.T) {
 	}
 	want := []byte(`[null,{"KA1":"EA1","KA2":"EA2","KA3":"EA3"},{"KB1":"EB1","KB2":"EB2"},{}]`)
 
-	enc := NewSliceEncoder([]map[string]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewSliceEncoderWithConfig([]map[string]string{}, cfg)
 
 	buf := NewBufferFromPool()
 	defer buf.ReturnToPool()
@@ -436,7 +442,9 @@ func TestSliceEncoder_ptrmap(t *testing.T) {
 	}
 	want := []byte(`[null,{"KA1":"EA1","KA2":"EA2","KA3":"EA3"},{"KB1":"EB1","KB2":"EB2"},{}]`)
 
-	enc := NewSliceEncoder([]*map[string]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewSliceEncoderWithConfig([]*map[string]string{}, cfg)
 
 	buf := NewBufferFromPool()
 	defer buf.ReturnToPool()

--- a/mapencoder.go
+++ b/mapencoder.go
@@ -504,7 +504,7 @@ func (e *MapEncoder) instr(kconv, econv func(unsafe.Pointer, *Buffer)) {
 func DefaultConfig() Config {
 
 	c := Config{}
-	c.SetSortMapKeys(true)
+	c.SetSortMapKeys(false)
 	return c
 }
 

--- a/mapencoder.go
+++ b/mapencoder.go
@@ -1,0 +1,639 @@
+package jingo
+
+// mapencoder.go manages MapEncoder and its responsibilities.
+// MapEnder follows the same principle of structencoder.go in that it generates lightweight
+// instructions as part of its compile stage which are executed later during the Marshal.
+// The key differences are:
+// - a separate instruction for key (kconv) and element (econv)
+// - a hashmap iterator is used to iterate over the map
+// - accepts `Config` which used to enable/disable sorting keys prior to encoding the map
+// - there's fast instruction(s) for sorted & unsorted `map[string]string`
+
+import (
+	"bytes"
+	"encoding"
+	"reflect"
+	"sort"
+	"sync"
+	"unsafe"
+)
+
+// MapEncoder stores a set of instructions for building a JSON document from a map at runtime.
+type MapEncoder struct {
+	instruction func(t unsafe.Pointer, w *Buffer)
+	typ         unsafe.Pointer
+	ttKey       reflect.Type
+	ttElem      reflect.Type
+}
+
+// NewMapEncoder builds a new MapEncoder.
+func NewMapEncoder(t interface{}) *MapEncoder {
+	return NewMapEncoderWithConfig(t, DefaultConfig())
+}
+
+// Marshal executes the instruction set built up by NewMapEncoder.
+func (e MapEncoder) Marshal(s interface{}, w *Buffer) {
+
+	p := unsafe.Pointer(reflect.ValueOf(s).Pointer())
+	e.instruction(p, w)
+}
+
+var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+
+// NewMapEncoderWithConfig builds a new MapEncoder using Config provided.
+func NewMapEncoderWithConfig(t interface{}, cfg Config) *MapEncoder {
+
+	e := &MapEncoder{}
+
+	tt := reflect.TypeOf(t)
+
+	e.typ = (*eface)(unsafe.Pointer(&t)).typ
+
+	e.ttKey = tt.Key()
+	e.ttElem = tt.Elem()
+
+	if e.ttKey.Kind() == reflect.Ptr {
+		e.ttKey = e.ttKey.Elem()
+	}
+
+	if e.ttElem.Kind() == reflect.Ptr {
+		e.ttElem = e.ttElem.Elem()
+	}
+
+	if tt.Key().Kind() == reflect.String && tt.Elem().Kind() == reflect.String {
+
+		// With optimization:
+		// name                                               time/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8    762ns ± 2%
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8  306ns ± 0%
+		// name                                               alloc/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8    0.00B
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8  0.00B
+		// name                                               allocs/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8     0.00
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8   0.00
+		// Without optimization:
+		// name                                               time/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8    903ns ± 1%
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8  369ns ± 0%
+		// name                                               alloc/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8    0.00B
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8  0.00B
+		// name                                               allocs/op
+		// MapEncoder/Key:_string,_Elem:_string_(sorted)-8     0.00
+		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8   0.00
+
+		if cfg.SortMapKeys() {
+			e.sortStrStrInstr()
+			return e
+		}
+
+		e.strStrInstr()
+		return e
+	}
+
+	var econv func(unsafe.Pointer, *Buffer)
+
+	if tt.Elem().Implements(textMarshalerType) {
+		if tt.Elem().Kind() == reflect.Ptr {
+			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
+				k, _ := reflect.NewAt(e.ttElem, v).Interface().(encoding.TextMarshaler).MarshalText()
+				w.WriteByte('"')
+				ptrStringToBuf(unsafe.Pointer(&k), w)
+				w.WriteByte('"')
+			})
+		} else {
+			econv = func(v unsafe.Pointer, w *Buffer) {
+				k, _ := reflect.NewAt(e.ttElem, v).Interface().(encoding.TextMarshaler).MarshalText()
+				w.WriteByte('"')
+				ptrStringToBuf(unsafe.Pointer(&k), w)
+				w.WriteByte('"')
+			}
+		}
+
+		goto KeyInstr
+	}
+
+	switch tt.Elem().Kind() {
+	case reflect.Slice:
+		enc := NewSliceEncoder(reflect.New(tt.Elem()).Elem().Interface())
+		econv = func(v unsafe.Pointer, w *Buffer) {
+			var em interface{} = unsafe.Pointer(uintptr(v))
+			enc.Marshal(em, w)
+		}
+
+	case reflect.Struct:
+		enc := NewStructEncoder(reflect.New(tt.Elem()).Elem().Interface())
+		econv = func(v unsafe.Pointer, w *Buffer) {
+			var em interface{} = unsafe.Pointer(uintptr(v))
+			enc.Marshal(em, w)
+		}
+
+	case reflect.Map:
+		enc := NewMapEncoderWithConfig(reflect.New(tt.Elem()).Elem().Interface(), cfg)
+		econv = func(v unsafe.Pointer, w *Buffer) {
+			var em interface{} = unsafe.Pointer(uintptr(v))
+			enc.Marshal(em, w)
+		}
+
+	case reflect.Ptr:
+		switch tt.Elem().Elem().Kind() {
+		case reflect.Slice:
+			enc := NewSliceEncoder(reflect.New(tt.Elem().Elem()).Elem().Interface())
+			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
+				var em interface{} = unsafe.Pointer(uintptr(v))
+				enc.Marshal(em, w)
+			})
+
+		case reflect.Struct:
+			enc := NewStructEncoder(reflect.New(tt.Elem().Elem()).Elem().Interface())
+			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
+				var em interface{} = unsafe.Pointer(uintptr(v))
+				enc.Marshal(em, w)
+			})
+
+		case reflect.Map:
+			enc := NewMapEncoderWithConfig(reflect.New(tt.Elem().Elem()).Elem().Interface(), cfg)
+			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
+				var em interface{} = unsafe.Pointer(uintptr(v))
+				enc.Marshal(em, w)
+			})
+
+		case reflect.String:
+			econv = e.ptrStrElemInstr()
+
+		case reflect.Bool,
+			reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64,
+			reflect.Uint,
+			reflect.Uint8,
+			reflect.Uint16,
+			reflect.Uint32,
+			reflect.Uint64,
+			reflect.Float32,
+			reflect.Float64:
+			econv = e.ptrElemInstr(typeconv[tt.Elem().Elem().Kind()])
+
+		default:
+			panic("unsupported ptr elem type")
+		}
+
+	case reflect.String:
+		econv = func(v unsafe.Pointer, w *Buffer) {
+			w.WriteByte('"')
+			ptrStringToBuf(v, w)
+			w.WriteByte('"')
+		}
+
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Float32,
+		reflect.Float64:
+		econv = typeconv[tt.Elem().Kind()]
+
+	default:
+		panic("unsupported elem type")
+	}
+KeyInstr:
+
+	var kconv func(unsafe.Pointer, *Buffer)
+
+	switch tt.Key().Kind() {
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.String:
+		kconv = typeconv[tt.Key().Kind()]
+
+	default:
+
+		if tt.Key().Implements(textMarshalerType) {
+			if tt.Key().Kind() == reflect.Ptr {
+				kconv = e.ptrKeyInstr(func(v unsafe.Pointer, w *Buffer) {
+					k, _ := reflect.NewAt(e.ttKey, v).Interface().(encoding.TextMarshaler).MarshalText()
+					ptrStringToBuf(unsafe.Pointer(&k), w)
+				})
+
+				break
+			}
+
+			kconv = func(v unsafe.Pointer, w *Buffer) {
+				k, _ := reflect.NewAt(e.ttKey, v).Interface().(encoding.TextMarshaler).MarshalText()
+				ptrStringToBuf(unsafe.Pointer(&k), w)
+			}
+
+			break
+		}
+		panic("unsupported key type")
+	}
+
+	if cfg.SortMapKeys() {
+
+		e.sortInstr(kconv, econv)
+		return e
+	}
+
+	e.instr(kconv, econv)
+
+	return e
+}
+
+// ptrStrElemInstr creates an instruction to read from a pointer field we're marshaling
+func (e *MapEncoder) ptrStrElemInstr() func(unsafe.Pointer, *Buffer) {
+	return func(v unsafe.Pointer, w *Buffer) {
+
+		p := *(*unsafe.Pointer)(v)
+		if p == unsafe.Pointer(nil) {
+			w.Write(null)
+			return
+		}
+
+		w.WriteByte('"')
+		ptrStringToBuf(p, w)
+		w.WriteByte('"')
+	}
+}
+
+// ptrElemInstr creates an instruction to read from a pointer field we're marshaling
+func (e *MapEncoder) ptrElemInstr(conv func(unsafe.Pointer, *Buffer)) func(unsafe.Pointer, *Buffer) {
+	return func(v unsafe.Pointer, w *Buffer) {
+
+		p := *(*unsafe.Pointer)(v)
+		if p == unsafe.Pointer(nil) {
+			w.Write(null)
+			return
+		}
+
+		conv(p, w)
+	}
+}
+
+// ptrKeyInstr creates an instruction to read from a pointer field we're marshaling
+func (e *MapEncoder) ptrKeyInstr(conv func(unsafe.Pointer, *Buffer)) func(unsafe.Pointer, *Buffer) {
+	return func(v unsafe.Pointer, w *Buffer) {
+
+		p := *(*unsafe.Pointer)(v)
+		if p == unsafe.Pointer(nil) {
+			// write empty quotes for nil keys
+			return
+		}
+
+		conv(p, w)
+	}
+}
+
+var emptyObj = []byte("{}")
+
+func (e *MapEncoder) sortStrStrInstr() {
+
+	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+
+		m := *(*unsafe.Pointer)(p)
+
+		if m == nil {
+			w.Write(null)
+			return
+		}
+
+		mlen := maplen(m)
+
+		if mlen == 0 {
+			w.Write(emptyObj)
+			return
+		}
+
+		it := newhiter(e.typ, m)
+		mapSlice := newMapSliceFromPool()
+
+		for ; it.key != nil; mapiternext(it) {
+
+			sl := (*sliceHeader)(it.key)
+			mapSlice.kvs = append(mapSlice.kvs, unsafeke{*sl, it.elem})
+		}
+
+		hiterPool.Put(it)
+		sort.Sort(mapSlice)
+
+		w.Write([]byte(`{"`))
+
+		for i, l := 0, mlen; i < l; i++ {
+
+			if i != 0 {
+				w.Write([]byte(`","`))
+			}
+
+			ptrStringToBuf(unsafe.Pointer(&mapSlice.kvs[i].k), w)
+			w.Write([]byte(`":"`))
+			ptrStringToBuf(mapSlice.kvs[i].e, w)
+		}
+
+		mapSlice.ReturnToPool()
+
+		w.Write([]byte(`"}`))
+	}
+}
+
+func (e *MapEncoder) strStrInstr() {
+
+	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+
+		m := *(*unsafe.Pointer)(p)
+
+		if m == nil {
+			w.Write(null)
+			return
+		}
+
+		if maplen(m) == 0 {
+			w.Write(emptyObj)
+			return
+		}
+
+		w.Write([]byte(`{"`))
+
+		it := newhiter(e.typ, m)
+
+		for i := 0; it.key != nil; mapiternext(it) {
+
+			if i != 0 {
+				w.Write([]byte(`","`))
+			}
+
+			ptrStringToBuf(it.key, w)
+			w.Write([]byte(`":"`))
+			ptrStringToBuf(it.elem, w)
+
+			i++
+		}
+
+		hiterPool.Put(it)
+
+		w.Write([]byte(`"}`))
+	}
+}
+
+func (e *MapEncoder) sortInstr(kconv, econv func(unsafe.Pointer, *Buffer)) {
+
+	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+
+		m := *(*unsafe.Pointer)(p)
+
+		if m == nil {
+			w.Write(null)
+			return
+		}
+
+		mlen := maplen(m)
+
+		if mlen == 0 {
+			w.Write(emptyObj)
+			return
+		}
+
+		var (
+			bufStart = len(w.Bytes)
+			ptrBuf   = unsafe.Pointer(&w.Bytes)
+			sl       = (*sliceHeader)(ptrBuf)
+		)
+
+		it := newhiter(e.typ, m)
+		mapSlice := newMapSliceFromPool()
+
+		for i := 0; it.key != nil; mapiternext(it) {
+
+			start := len(w.Bytes)
+			kconv(it.key, w)
+
+			klen := len(w.Bytes) - start
+
+			mapSlice.kvs = append(mapSlice.kvs,
+				unsafeke{
+					k: sliceHeader{unsafe.Pointer(uintptr(sl.Data) + uintptr(start)), klen, klen},
+					e: it.elem,
+				})
+
+			i++
+		}
+
+		hiterPool.Put(it)
+
+		bufEnd := len(w.Bytes)
+
+		sort.Sort(mapSlice)
+
+		w.Write([]byte(`{"`))
+
+		for i, l := 0, mlen; i < l; i++ {
+
+			if i != 0 {
+				w.Write([]byte(`,"`))
+			}
+
+			w.Bytes = append(w.Bytes, *(*[]byte)(unsafe.Pointer(&mapSlice.kvs[i].k))...)
+			w.Write([]byte(`":`))
+			econv(mapSlice.kvs[i].e, w)
+		}
+		mapSlice.ReturnToPool()
+
+		w.Bytes = append(w.Bytes[:bufStart], w.Bytes[bufEnd:]...)
+		w.WriteByte('}')
+	}
+}
+
+func (e *MapEncoder) instr(kconv, econv func(unsafe.Pointer, *Buffer)) {
+
+	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+
+		m := *(*unsafe.Pointer)(p)
+
+		if m == nil {
+			w.Write(null)
+			return
+		}
+
+		if maplen(m) == 0 {
+			w.Write(emptyObj)
+			return
+		}
+
+		w.Write([]byte(`{"`))
+
+		it := newhiter(e.typ, m)
+
+		for i := 0; it.key != nil; mapiternext(it) {
+
+			if i != 0 {
+				w.Write([]byte(`,"`))
+			}
+
+			kconv(it.key, w)
+			w.Write([]byte(`":`))
+			econv(it.elem, w)
+
+			i++
+		}
+
+		hiterPool.Put(it)
+		w.WriteByte('}')
+	}
+}
+
+// DefaultConfig returns DefaultConfiguration for NewEncoder instructions. By default, MapEncoders sort map keys when encoding JSON (recommended for encoding/json behaviour)
+func DefaultConfig() Config {
+
+	c := Config{}
+	c.SetSortMapKeys(true)
+	return c
+}
+
+// Config is a type used to represent configuration options that can be
+// applied when formatting json output.
+type Config struct {
+	mapEncoder uint8
+}
+
+const (
+	// map encoder
+	sortMapKeys uint8 = 1 << iota
+)
+
+// SetSortMapKeys specifies whether map keys are sorted before to encoding values to JSON. Setting `SortMapKeys` to off drastically improves performance for MapEncoders.
+func (c *Config) SetSortMapKeys(on bool) {
+	if on {
+		c.mapEncoder |= sortMapKeys
+		return
+	}
+
+	c.mapEncoder &= ^sortMapKeys
+}
+
+// SortMapKeys states whether SortMapKeys is on/off.
+func (c Config) SortMapKeys() bool {
+	return c.mapEncoder&sortMapKeys != 0
+}
+
+type eface struct {
+	typ  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+// A hash iteration structure.
+// Make sure this stays in sync with runtime/map.go.
+type hiter struct {
+	key  unsafe.Pointer
+	elem unsafe.Pointer
+
+	_ unsafe.Pointer //    t           unsafe.Pointer // *MapType
+	_ unsafe.Pointer //    h           *hmap
+	_ unsafe.Pointer //    buckets     *bmap
+	_ unsafe.Pointer //    bptr        *bmap
+	_ unsafe.Pointer //    overflow    unsafe.Pointer // *[]*bmap
+	_ unsafe.Pointer //    oldoverflow unsafe.Pointer // *[]*bmap
+	_ uintptr        //    startBucket uintptr
+	_ uint8          //    offset      uint8
+	_ bool           //    wrapped     bool
+	_ uint8          //    B           uint8
+	_ uint8          //    i           uint8
+	_ uintptr        //    bucket      uintptr
+	_ uintptr        //    checkBucket uintptr
+}
+
+var (
+	hiterPool sync.Pool
+	zeroHiter = &hiter{}
+)
+
+func newhiter(t, m unsafe.Pointer) *hiter {
+	v := hiterPool.Get()
+	if v == nil {
+		return mapiterinit(t, m)
+	}
+	it := v.(*hiter)
+	*it = *zeroHiter
+	runtimemapiterinit(t, m, unsafe.Pointer(it))
+	return it
+}
+
+//go:noescape
+//go:linkname mapiterinit reflect.mapiterinit
+func mapiterinit(unsafe.Pointer, unsafe.Pointer) *hiter
+
+//go:noescape
+//go:linkname mapiternext reflect.mapiternext
+func mapiternext(*hiter)
+
+//go:noescape
+//go:linkname runtimemapiterinit runtime.mapiterinit
+func runtimemapiterinit(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer)
+
+//go:noescape
+//go:linkname maplen reflect.maplen
+func maplen(unsafe.Pointer) int
+
+type mapSlice struct {
+	kvs []unsafeke
+}
+
+func (ms mapSlice) Len() int {
+	return len(ms.kvs)
+}
+
+func (ms mapSlice) Swap(i, j int) {
+	ms.kvs[i], ms.kvs[j] = ms.kvs[j], ms.kvs[i]
+}
+
+func (ms mapSlice) Less(i, j int) bool {
+	return bytes.Compare(*(*[]byte)(unsafe.Pointer(&ms.kvs[i].k)), *(*[]byte)(unsafe.Pointer(&ms.kvs[j].k))) < 0
+}
+
+func (ms *mapSlice) ReturnToPool() {
+	mapSlicePool.Put(ms)
+}
+
+func (ms *mapSlice) Reset() {
+	ms.kvs = ms.kvs[:0]
+}
+
+var mapSlicePool = sync.Pool{New: func() interface{} { return &mapSlice{} }}
+
+func newMapSliceFromPool() *mapSlice {
+	newMapSlice := mapSlicePool.Get().(*mapSlice)
+	newMapSlice.Reset()
+
+	return newMapSlice
+}
+
+type unsafeke struct {
+	k sliceHeader
+	e unsafe.Pointer
+}
+
+// src/reflect/value.go
+// sliceHeader is a safe version of SliceHeader used within this package.
+type sliceHeader struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
+}

--- a/mapencoder.go
+++ b/mapencoder.go
@@ -85,11 +85,11 @@ func NewMapEncoderWithConfig(t interface{}, cfg Config) *MapEncoder {
 		// MapEncoder/Key:_string,_Elem:_string_(unsorted)-8   0.00
 
 		if e.cfg.SortMapKeys() {
-			e.sortStrStrInstr()
+			e.instruction = e.sortStrStrInstr()
 			return e
 		}
 
-		e.strStrInstr()
+		e.instruction = e.strStrInstr()
 		return e
 	}
 
@@ -252,11 +252,11 @@ KeyInstr:
 
 	if e.cfg.SortMapKeys() {
 
-		e.sortInstr(kconv, econv)
+		e.instruction = e.sortInstr(kconv, econv)
 		return e
 	}
 
-	e.instr(kconv, econv)
+	e.instruction = e.instr(kconv, econv)
 
 	return e
 }
@@ -307,9 +307,9 @@ func (e *MapEncoder) ptrKeyInstr(conv func(unsafe.Pointer, *Buffer)) func(unsafe
 
 var emptyObj = []byte("{}")
 
-func (e *MapEncoder) sortStrStrInstr() {
+func (e *MapEncoder) sortStrStrInstr() func(unsafe.Pointer, *Buffer) {
 
-	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+	return func(p unsafe.Pointer, w *Buffer) {
 
 		m := *(*unsafe.Pointer)(p)
 
@@ -356,9 +356,9 @@ func (e *MapEncoder) sortStrStrInstr() {
 	}
 }
 
-func (e *MapEncoder) strStrInstr() {
+func (e *MapEncoder) strStrInstr() func(unsafe.Pointer, *Buffer) {
 
-	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+	return func(p unsafe.Pointer, w *Buffer) {
 
 		m := *(*unsafe.Pointer)(p)
 
@@ -395,9 +395,9 @@ func (e *MapEncoder) strStrInstr() {
 	}
 }
 
-func (e *MapEncoder) sortInstr(kconv, econv func(unsafe.Pointer, *Buffer)) {
+func (e *MapEncoder) sortInstr(kconv, econv func(unsafe.Pointer, *Buffer)) func(unsafe.Pointer, *Buffer) {
 
-	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+	return func(p unsafe.Pointer, w *Buffer) {
 
 		m := *(*unsafe.Pointer)(p)
 
@@ -463,9 +463,9 @@ func (e *MapEncoder) sortInstr(kconv, econv func(unsafe.Pointer, *Buffer)) {
 	}
 }
 
-func (e *MapEncoder) instr(kconv, econv func(unsafe.Pointer, *Buffer)) {
+func (e *MapEncoder) instr(kconv, econv func(unsafe.Pointer, *Buffer)) func(unsafe.Pointer, *Buffer) {
 
-	e.instruction = func(p unsafe.Pointer, w *Buffer) {
+	return func(p unsafe.Pointer, w *Buffer) {
 
 		m := *(*unsafe.Pointer)(p)
 

--- a/mapencoder.go
+++ b/mapencoder.go
@@ -116,14 +116,14 @@ func NewMapEncoderWithConfig(t interface{}, cfg Config) *MapEncoder {
 
 	switch tt.Elem().Kind() {
 	case reflect.Slice:
-		enc := NewSliceEncoder(reflect.New(tt.Elem()).Elem().Interface())
+		enc := NewSliceEncoderWithConfig(reflect.New(tt.Elem()).Elem().Interface(), cfg)
 		econv = func(v unsafe.Pointer, w *Buffer) {
 			var em interface{} = unsafe.Pointer(uintptr(v))
 			enc.Marshal(em, w)
 		}
 
 	case reflect.Struct:
-		enc := NewStructEncoder(reflect.New(tt.Elem()).Elem().Interface())
+		enc := NewStructEncoderWithConfig(reflect.New(tt.Elem()).Elem().Interface(), cfg)
 		econv = func(v unsafe.Pointer, w *Buffer) {
 			var em interface{} = unsafe.Pointer(uintptr(v))
 			enc.Marshal(em, w)
@@ -139,14 +139,14 @@ func NewMapEncoderWithConfig(t interface{}, cfg Config) *MapEncoder {
 	case reflect.Ptr:
 		switch tt.Elem().Elem().Kind() {
 		case reflect.Slice:
-			enc := NewSliceEncoder(reflect.New(tt.Elem().Elem()).Elem().Interface())
+			enc := NewSliceEncoderWithConfig(reflect.New(tt.Elem().Elem()).Elem().Interface(), cfg)
 			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
 				var em interface{} = unsafe.Pointer(uintptr(v))
 				enc.Marshal(em, w)
 			})
 
 		case reflect.Struct:
-			enc := NewStructEncoder(reflect.New(tt.Elem().Elem()).Elem().Interface())
+			enc := NewStructEncoderWithConfig(reflect.New(tt.Elem().Elem()).Elem().Interface(), cfg)
 			econv = e.ptrElemInstr(func(v unsafe.Pointer, w *Buffer) {
 				var em interface{} = unsafe.Pointer(uintptr(v))
 				enc.Marshal(em, w)

--- a/mapencoder_bench_test.go
+++ b/mapencoder_bench_test.go
@@ -1,0 +1,126 @@
+package jingo
+
+import (
+	"testing"
+)
+
+func BenchmarkMapEncoder(b *testing.B) {
+
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(false)
+
+	for _, bb := range []struct {
+		name    string
+		encoder marshaler
+		s       interface{}
+	}{
+		{
+			"Key: string, Elem: string (sorted)",
+			NewMapEncoder(map[string]string{}),
+			&map[string]string{
+				"10": "1",
+				"9":  "2",
+				"8":  "3",
+				"7":  "4",
+				"6":  "5",
+				"5":  "6",
+				"4":  "7",
+				"3":  "8",
+				"2":  "9",
+				"1":  "10",
+			},
+		},
+		{
+			"Key: string, Elem: string (unsorted)",
+			NewMapEncoderWithConfig(map[string]string{}, cfg),
+			&map[string]string{
+				"10": "1",
+				"9":  "2",
+				"8":  "3",
+				"7":  "4",
+				"6":  "5",
+				"5":  "6",
+				"4":  "7",
+				"3":  "8",
+				"2":  "9",
+				"1":  "10",
+			},
+		},
+		{
+			"Key: int, Elem: string (sorted)",
+			NewMapEncoder(map[int]string{}),
+			&map[int]string{
+				10: "1",
+				9:  "2",
+				8:  "3",
+				7:  "4",
+				6:  "5",
+				5:  "6",
+				4:  "7",
+				3:  "8",
+				2:  "9",
+				1:  "10",
+			},
+		},
+		{
+			"Key: int, Elem: string (unsorted)",
+			NewMapEncoderWithConfig(map[int]string{}, cfg),
+			&map[int]string{
+				10: "1",
+				9:  "2",
+				8:  "3",
+				7:  "4",
+				6:  "5",
+				5:  "6",
+				4:  "7",
+				3:  "8",
+				2:  "9",
+				1:  "10",
+			},
+		},
+		{
+			"Key: MarshalText, Elem: string (sorted)",
+			NewMapEncoder(map[*textStruct]string{}),
+			&map[*textStruct]string{
+				{[]byte("10")}: "1",
+				{[]byte("9")}:  "2",
+				{[]byte("8")}:  "3",
+				{[]byte("7")}:  "4",
+				{[]byte("6")}:  "5",
+				{[]byte("5")}:  "6",
+				{[]byte("4")}:  "7",
+				{[]byte("3")}:  "8",
+				{[]byte("2")}:  "9",
+				{[]byte("1")}:  "10",
+			},
+		},
+		{
+			"Key: MarshalText, Elem: string (unsorted)",
+			NewMapEncoderWithConfig(map[*textStruct]string{}, cfg),
+			&map[*textStruct]string{
+				{[]byte("10")}: "1",
+				{[]byte("9")}:  "2",
+				{[]byte("8")}:  "3",
+				{[]byte("7")}:  "4",
+				{[]byte("6")}:  "5",
+				{[]byte("5")}:  "6",
+				{[]byte("4")}:  "7",
+				{[]byte("3")}:  "8",
+				{[]byte("2")}:  "9",
+				{[]byte("1")}:  "10",
+			},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+
+				buf := NewBufferFromPool()
+
+				bb.encoder.Marshal(bb.s, buf)
+
+				buf.ReturnToPool()
+			}
+		})
+	}
+}

--- a/mapencoder_bench_test.go
+++ b/mapencoder_bench_test.go
@@ -7,7 +7,7 @@ import (
 func BenchmarkMapEncoder(b *testing.B) {
 
 	cfg := DefaultConfig()
-	cfg.SetSortMapKeys(false)
+	cfg.SetSortMapKeys(true)
 
 	for _, bb := range []struct {
 		name    string
@@ -15,7 +15,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 		s       interface{}
 	}{
 		{
-			"Key: string, Elem: string (sorted)",
+			"Key: string, Elem: string",
 			NewMapEncoder(map[string]string{}),
 			&map[string]string{
 				"10": "1",
@@ -31,7 +31,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 			},
 		},
 		{
-			"Key: string, Elem: string (unsorted)",
+			"Key: string, Elem: string sorted",
 			NewMapEncoderWithConfig(map[string]string{}, cfg),
 			&map[string]string{
 				"10": "1",
@@ -47,7 +47,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 			},
 		},
 		{
-			"Key: int, Elem: string (sorted)",
+			"Key: int, Elem: string",
 			NewMapEncoder(map[int]string{}),
 			&map[int]string{
 				10: "1",
@@ -63,7 +63,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 			},
 		},
 		{
-			"Key: int, Elem: string (unsorted)",
+			"Key: int, Elem: string sorted",
 			NewMapEncoderWithConfig(map[int]string{}, cfg),
 			&map[int]string{
 				10: "1",
@@ -79,7 +79,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 			},
 		},
 		{
-			"Key: MarshalText, Elem: string (sorted)",
+			"Key: MarshalText, Elem: string",
 			NewMapEncoder(map[*textStruct]string{}),
 			&map[*textStruct]string{
 				{[]byte("10")}: "1",
@@ -95,7 +95,7 @@ func BenchmarkMapEncoder(b *testing.B) {
 			},
 		},
 		{
-			"Key: MarshalText, Elem: string (unsorted)",
+			"Key: MarshalText, Elem: string sorted",
 			NewMapEncoderWithConfig(map[*textStruct]string{}, cfg),
 			&map[*textStruct]string{
 				{[]byte("10")}: "1",

--- a/mapencoder_test.go
+++ b/mapencoder_test.go
@@ -1,0 +1,890 @@
+package jingo
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMapEncoderUnsupportedTypeError(t *testing.T) {
+
+	tests := []struct {
+		name string
+		t    interface{}
+		want string
+	}{
+		{
+			"unsupported key type: struct",
+			map[struct{}]string{},
+			"unsupported key type",
+		},
+		{
+			"unsupported elem type: chan",
+			map[string]chan string{},
+			"unsupported elem type",
+		},
+		{
+			"unsupported elem type: chan",
+			map[string]*chan string{},
+			"unsupported ptr elem type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			defer func() {
+				v := recover().(string)
+
+				if v != tt.want {
+					t.Fatalf("\nWanted:\n%q\nGot:\n%q", tt.want, v)
+				}
+			}()
+			NewMapEncoder(tt.t)
+		})
+	}
+}
+
+type textStruct struct {
+	text []byte
+}
+
+func (t textStruct) MarshalText() ([]byte, error) { return t.text, nil }
+
+var _ encoding.TextMarshaler = &textStruct{}
+
+func TestMapEncoder_key_marshaltext(t *testing.T) {
+
+	enc := NewMapEncoder(map[*textStruct]string{})
+
+	tests := []struct {
+		name string
+		v    map[*textStruct]string
+		want []byte
+	}{
+		{
+			"Nil",
+			map[*textStruct]string(nil),
+			[]byte(`null`),
+		},
+		{
+			"Empty",
+			map[*textStruct]string{},
+			[]byte(`{}`),
+		},
+		{
+			"Nil Key",
+			map[*textStruct]string{{nil}: "aa"},
+			[]byte(`{"":"aa"}`),
+		},
+		{
+			"Non-nil key",
+			map[*textStruct]string{{[]byte("1")}: "aa"},
+			[]byte(`{"1":"aa"}`),
+		},
+		{
+			"Many",
+			map[*textStruct]string{
+				{[]byte("2")}: "aa",
+				{[]byte("3")}: "bb",
+				{[]byte("1")}: "cc",
+				{nil}:         "dd",
+			},
+			[]byte(`{"":"dd","1":"cc","2":"aa","3":"bb"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_key_time(t *testing.T) {
+
+	enc := NewMapEncoder(map[time.Time]string{})
+
+	d0 := time.Date(2000, 9, 17, 20, 4, 26, 0, time.UTC)
+	d1 := time.Date(2001, 9, 17, 20, 4, 26, 0, time.UTC)
+	d2 := time.Date(2002, 9, 17, 20, 4, 26, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		v    map[time.Time]string
+		want []byte
+	}{
+		{
+			"One",
+			map[time.Time]string{
+				d0: "1",
+			},
+			[]byte(`{"2000-09-17T20:04:26Z":"1"}`),
+		},
+		{
+			"Many",
+			map[time.Time]string{
+				d0: "1",
+				d1: "2",
+				d2: "3",
+			},
+			[]byte(`{"2000-09-17T20:04:26Z":"1","2001-09-17T20:04:26Z":"2","2002-09-17T20:04:26Z":"3"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_key_ptrtime(t *testing.T) {
+
+	enc := NewMapEncoder(map[*time.Time]string{})
+
+	d0 := time.Date(2000, 9, 17, 20, 4, 26, 0, time.UTC)
+	d1 := time.Date(2001, 9, 17, 20, 4, 26, 0, time.UTC)
+	d2 := time.Date(2002, 9, 17, 20, 4, 26, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		v    map[*time.Time]string
+		want []byte
+	}{
+		{
+			"Nil",
+			map[*time.Time]string{
+				nil: "1",
+			},
+			[]byte(`{"":"1"}`),
+		},
+		{
+			"Non-nil",
+			map[*time.Time]string{
+				&d0: "1",
+			},
+			[]byte(`{"2000-09-17T20:04:26Z":"1"}`),
+		},
+		{
+			"Many",
+			map[*time.Time]string{
+				nil: "1",
+				&d0: "2",
+				&d1: "3",
+				&d2: "4",
+			},
+			[]byte(`{"":"1","2000-09-17T20:04:26Z":"2","2001-09-17T20:04:26Z":"3","2002-09-17T20:04:26Z":"4"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+type innerStruct struct {
+	S string `json:"s"`
+}
+
+func TestMapEncoder_elem_struct(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]innerStruct{})
+
+	tests := []struct {
+		name string
+		v    map[string]innerStruct
+		want []byte
+	}{
+		{
+			"One",
+			map[string]innerStruct{"a": {"s0"}},
+			[]byte(`{"a":{"s":"s0"}}`),
+		},
+		{
+			"Many",
+			map[string]innerStruct{"a": {"s1"}, "b": {"s2"}, "c": {"s3"}},
+			[]byte(`{"a":{"s":"s1"},"b":{"s":"s2"},"c":{"s":"s3"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_ptrstruct(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*innerStruct{})
+
+	var (
+		s0 = innerStruct{"s0"}
+		s1 = innerStruct{"s1"}
+	)
+
+	tests := []struct {
+		name string
+		v    map[string]*innerStruct
+		want []byte
+	}{
+		{
+			"Nil",
+			map[string]*innerStruct{"a": nil},
+			[]byte(`{"a":null}`),
+		},
+		{
+			"One",
+			map[string]*innerStruct{
+				"a": &s0,
+			},
+			[]byte(`{"a":{"s":"s0"}}`),
+		},
+		{
+			"Many",
+			map[string]*innerStruct{
+				"a": &s0,
+				"b": &s1,
+				"c": nil,
+			},
+			[]byte(`{"a":{"s":"s0"},"b":{"s":"s1"},"c":null}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_slice(t *testing.T) {
+
+	enc := NewMapEncoder(map[string][]int{})
+
+	tests := []struct {
+		name string
+		v    map[string][]int
+		want []byte
+	}{
+		{
+			"nil",
+			map[string][]int{"a": nil},
+			[]byte(`{"a":[]}`),
+		},
+		{
+			"One",
+			map[string][]int{"a": {1, 2, 3}},
+			[]byte(`{"a":[1,2,3]}`),
+		},
+		{
+			"Many",
+			map[string][]int{"a": {1, 2, 3}, "b": {4, 5, 6}, "c": nil},
+			[]byte(`{"a":[1,2,3],"b":[4,5,6],"c":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_ptrslice(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*[]int{})
+
+	var (
+		s0 = []int{1, 2, 3}
+		s1 = []int{4, 5, 6}
+	)
+
+	tests := []struct {
+		name string
+		v    map[string]*[]int
+		want []byte
+	}{
+		{
+			"nil",
+			map[string]*[]int{"a": nil},
+			[]byte(`{"a":null}`),
+		},
+		{
+			"One",
+			map[string]*[]int{"a": &s0},
+			[]byte(`{"a":[1,2,3]}`),
+		},
+		{
+			"Many",
+			map[string]*[]int{"a": &s0, "b": &s1, "c": nil},
+			[]byte(`{"a":[1,2,3],"b":[4,5,6],"c":null}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_map(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]map[string]string{})
+
+	tests := []struct {
+		name string
+		v    map[string]map[string]string
+		want []byte
+	}{
+		{
+			"Nil",
+			map[string]map[string]string(nil),
+			[]byte(`null`),
+		},
+		{
+			"Empty",
+			map[string]map[string]string{},
+			[]byte(`{}`),
+		},
+		{
+			"One - Nil Elem",
+			map[string]map[string]string{"1": nil},
+			[]byte(`{"1":null}`),
+		},
+		{
+			"One",
+			map[string]map[string]string{"1": {"KA": "EA"}},
+			[]byte(`{"1":{"KA":"EA"}}`),
+		},
+		{
+			"Many",
+			map[string]map[string]string{
+				"1": {"KA": "EA"},
+				"2": {"KB1": "EB1", "KB2": "EB2", "KB3": "EK3"},
+				"3": {"KC1": "EC1", "KC2": "EC2"},
+			},
+			[]byte(`{"1":{"KA":"EA"},"2":{"KB1":"EB1","KB2":"EB2","KB3":"EK3"},"3":{"KC1":"EC1","KC2":"EC2"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_ptrmap(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*map[string]string{})
+
+	var (
+		m1 = map[string]string{"KA1": "EA1"}
+		m2 = map[string]string{"KB1": "EB1", "KB2": "EB2", "KB3": "EK3"}
+		m3 = map[string]string{"KC1": "EC1", "KC2": "EC2"}
+	)
+
+	tests := []struct {
+		name string
+		v    map[string]*map[string]string
+		want []byte
+	}{
+		{
+			"One - Nil Elem",
+			map[string]*map[string]string{"1": nil},
+			[]byte(`{"1":null}`),
+		},
+		{
+			"One",
+			map[string]*map[string]string{"1": &m1},
+			[]byte(`{"1":{"KA1":"EA1"}}`),
+		},
+		{
+			"Many",
+			map[string]*map[string]string{
+				"1": &m1,
+				"2": &m2,
+				"3": &m3,
+				"4": nil,
+			},
+			[]byte(`{"1":{"KA1":"EA1"},"2":{"KB1":"EB1","KB2":"EB2","KB3":"EK3"},"3":{"KC1":"EC1","KC2":"EC2"},"4":null}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_ptrstring(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*string{})
+
+	var (
+		aa = "aa"
+		bb = "bb"
+		cc = "cc"
+	)
+
+	tests := []struct {
+		name string
+		v    map[string]*string
+		want []byte
+	}{
+		{
+			"Nil",
+			map[string]*string(nil),
+			[]byte(`null`),
+		},
+		{
+			"Empty",
+			map[string]*string{},
+			[]byte(`{}`),
+		},
+		{
+			"One - Nil",
+			map[string]*string{"1": nil},
+			[]byte(`{"1":null}`),
+		},
+		{
+			"One",
+			map[string]*string{"2": &aa},
+			[]byte(`{"2":"aa"}`),
+		},
+		{
+			"Many - Mixed",
+			map[string]*string{"3": nil, "2": &cc, "1": nil},
+			[]byte(`{"1":null,"2":"cc","3":null}`),
+		},
+		{
+			"Many",
+			map[string]*string{"3": &aa, "1": &bb, "2": &cc},
+			[]byte(`{"1":"bb","2":"cc","3":"aa"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_nonstring(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]int{})
+
+	tests := []struct {
+		name string
+		v    map[string]int
+		want []byte
+	}{
+		{
+			"One",
+			map[string]int{"2": 1},
+			[]byte(`{"2":1}`),
+		},
+		{
+			"Many",
+			map[string]int{"3": 1, "1": 2, "2": 3},
+			[]byte(`{"1":2,"2":3,"3":1}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+func TestMapEncoder_elem_ptrnonstring(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*int{})
+
+	var (
+		one   = 1
+		two   = 2
+		three = 3
+	)
+
+	tests := []struct {
+		name string
+		v    map[string]*int
+		want []byte
+	}{
+		{
+			"One - Nil",
+			map[string]*int{"2": nil},
+			[]byte(`{"2":null}`),
+		},
+		{
+			"One",
+			map[string]*int{"2": &one},
+			[]byte(`{"2":1}`),
+		},
+		{
+			"Many - Mixed",
+			map[string]*int{"3": nil, "2": &three, "1": nil},
+			[]byte(`{"1":null,"2":3,"3":null}`),
+		},
+		{
+			"Many",
+			map[string]*int{"3": &one, "1": &two, "2": &three},
+			[]byte(`{"1":2,"2":3,"3":1}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+func TestMapEncoder_elem_marshaltext(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]textStruct{})
+
+	tests := []struct {
+		name string
+		v    map[string]textStruct
+		want []byte
+	}{
+		{
+			"One - Nil",
+			map[string]textStruct{"1": {nil}},
+			[]byte(`{"1":""}`),
+		},
+		{
+			"One",
+			map[string]textStruct{"1": {[]byte("aa")}},
+			[]byte(`{"1":"aa"}`),
+		},
+		{
+			"Many",
+			map[string]textStruct{"1": {[]byte("aa")}, "2": {[]byte("bb")}, "3": {[]byte("cc")}, "4": {nil}},
+			[]byte(`{"1":"aa","2":"bb","3":"cc","4":""}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_elem_ptrmarshaltext(t *testing.T) {
+
+	enc := NewMapEncoder(map[string]*textStruct{})
+
+	aa := &textStruct{[]byte("aa")}
+
+	tests := []struct {
+		name string
+		v    map[string]*textStruct
+		want []byte
+	}{
+		{
+			"One - Nil Elem",
+			map[string]*textStruct{"1": nil},
+			[]byte(`{"1":null}`),
+		},
+		{
+			"One - Nil Elem Value",
+			map[string]*textStruct{"1": nil},
+			[]byte(`{"1":null}`),
+		},
+		{
+			"One",
+			map[string]*textStruct{"1": aa},
+			[]byte(`{"1":"aa"}`),
+		},
+		{
+			"Many",
+			map[string]*textStruct{
+				"1": {[]byte("aa")},
+				"2": {[]byte("bb")},
+				"3": {[]byte("cc")},
+				"4": {nil},
+				"5": nil,
+			},
+			[]byte(`{"1":"aa","2":"bb","3":"cc","4":"","5":null}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			enc.Marshal(&tt.v, buf)
+
+			if !bytes.Equal(tt.want, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s\n", tt.want, buf.Bytes)
+			}
+		})
+	}
+}
+
+type marshaler interface {
+	Marshal(s interface{}, w *Buffer)
+}
+
+func TestMapEncoder_sorted_nonstring(t *testing.T) {
+
+	tests := []struct {
+		name string
+		enc  marshaler
+		v    interface{}
+	}{
+		{
+			"key: int",
+			NewMapEncoder(map[int]string{}),
+			&map[int]string{
+				4:        "A",
+				59:       "B",
+				238:      "C",
+				-784:     "D",
+				9845:     "E",
+				959:      "F",
+				905:      "G",
+				0:        "H",
+				42:       "I",
+				7586:     "J",
+				-5467984: "K",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+
+			tt.enc.Marshal(tt.v, buf)
+
+			bs, err := json.Marshal(tt.v)
+			if err != nil {
+				t.Fatalf("Unable to marshal value %s", err)
+			}
+
+			if !bytes.Equal(bs, buf.Bytes) {
+				t.Errorf("\nwant:\n%s\ngot:\n%s", bs, buf.Bytes)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_unsorted_fast_string(t *testing.T) {
+
+	var cfg Config
+	cfg.SetSortMapKeys(false)
+
+	enc := NewMapEncoderWithConfig(map[string]string{}, cfg)
+
+	tests := []struct {
+		name string
+		v    map[string]string
+	}{
+		{
+			"Nil",
+			map[string]string(nil),
+		},
+		{
+			"Empty",
+			map[string]string{},
+		},
+		{
+			"One",
+			map[string]string{"aa": "123"},
+		},
+		{
+			"Many",
+			map[string]string{"bb": "678", "cc": "345", "aa": "123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+			enc.Marshal(&tt.v, buf)
+
+			var dst map[string]string
+
+			if err := json.Unmarshal(buf.Bytes, &dst); err != nil {
+				t.Fatalf("Unable to unmarshal buf.Bytes -  %s", err)
+			}
+
+			if !reflect.DeepEqual(tt.v, dst) {
+				t.Fatalf("buf.Bytes=%q\nWant:%+v\nGot:%+v", buf.Bytes, tt.v, dst)
+			}
+		})
+	}
+}
+
+func TestMapEncoder_unsorted_non_string(t *testing.T) {
+
+	var cfg Config
+	cfg.SetSortMapKeys(false)
+
+	enc := NewMapEncoderWithConfig(map[int]string{}, cfg)
+
+	tests := []struct {
+		name string
+		v    map[int]string
+	}{
+		{
+			"Nil",
+			map[int]string(nil),
+		},
+		{
+			"Empty",
+			map[int]string{},
+		},
+		{
+			"One",
+			map[int]string{2: "aa"},
+		},
+		{
+			"Many",
+			map[int]string{3: "cc", 1: "bb", 2: "aa", 4: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := NewBufferFromPool()
+			defer buf.ReturnToPool()
+			enc.Marshal(&tt.v, buf)
+
+			var dst map[int]string
+
+			if err := json.Unmarshal(buf.Bytes, &dst); err != nil {
+				t.Fatalf("Unable to unmarshal buf.Bytes -  %s\nbuf.Bytes=%s", err, buf.Bytes)
+			}
+
+			if !reflect.DeepEqual(tt.v, dst) {
+				t.Fatalf("\nWant:%+v\nGot:%+v\nbuf.Bytes=%s", tt.v, dst, buf.Bytes)
+			}
+		})
+	}
+}

--- a/mapencoder_test.go
+++ b/mapencoder_test.go
@@ -58,7 +58,10 @@ var _ encoding.TextMarshaler = &textStruct{}
 
 func TestMapEncoder_key_marshaltext(t *testing.T) {
 
-	enc := NewMapEncoder(map[*textStruct]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+
+	enc := NewMapEncoderWithConfig(map[*textStruct]string{}, cfg)
 
 	tests := []struct {
 		name string
@@ -114,7 +117,9 @@ func TestMapEncoder_key_marshaltext(t *testing.T) {
 
 func TestMapEncoder_key_time(t *testing.T) {
 
-	enc := NewMapEncoder(map[time.Time]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[time.Time]string{}, cfg)
 
 	d0 := time.Date(2000, 9, 17, 20, 4, 26, 0, time.UTC)
 	d1 := time.Date(2001, 9, 17, 20, 4, 26, 0, time.UTC)
@@ -160,7 +165,9 @@ func TestMapEncoder_key_time(t *testing.T) {
 
 func TestMapEncoder_key_ptrtime(t *testing.T) {
 
-	enc := NewMapEncoder(map[*time.Time]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[*time.Time]string{}, cfg)
 
 	d0 := time.Date(2000, 9, 17, 20, 4, 26, 0, time.UTC)
 	d1 := time.Date(2001, 9, 17, 20, 4, 26, 0, time.UTC)
@@ -218,7 +225,9 @@ type innerStruct struct {
 
 func TestMapEncoder_elem_struct(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]innerStruct{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]innerStruct{}, cfg)
 
 	tests := []struct {
 		name string
@@ -254,7 +263,9 @@ func TestMapEncoder_elem_struct(t *testing.T) {
 
 func TestMapEncoder_elem_ptrstruct(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*innerStruct{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*innerStruct{}, cfg)
 
 	var (
 		s0 = innerStruct{"s0"}
@@ -306,7 +317,9 @@ func TestMapEncoder_elem_ptrstruct(t *testing.T) {
 
 func TestMapEncoder_elem_slice(t *testing.T) {
 
-	enc := NewMapEncoder(map[string][]int{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string][]int{}, cfg)
 
 	tests := []struct {
 		name string
@@ -347,7 +360,9 @@ func TestMapEncoder_elem_slice(t *testing.T) {
 
 func TestMapEncoder_elem_ptrslice(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*[]int{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*[]int{}, cfg)
 
 	var (
 		s0 = []int{1, 2, 3}
@@ -393,7 +408,9 @@ func TestMapEncoder_elem_ptrslice(t *testing.T) {
 
 func TestMapEncoder_elem_map(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]map[string]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]map[string]string{}, cfg)
 
 	tests := []struct {
 		name string
@@ -448,7 +465,9 @@ func TestMapEncoder_elem_map(t *testing.T) {
 
 func TestMapEncoder_elem_ptrmap(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*map[string]string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*map[string]string{}, cfg)
 
 	var (
 		m1 = map[string]string{"KA1": "EA1"}
@@ -500,7 +519,9 @@ func TestMapEncoder_elem_ptrmap(t *testing.T) {
 
 func TestMapEncoder_elem_ptrstring(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*string{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*string{}, cfg)
 
 	var (
 		aa = "aa"
@@ -562,7 +583,9 @@ func TestMapEncoder_elem_ptrstring(t *testing.T) {
 
 func TestMapEncoder_elem_nonstring(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]int{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]int{}, cfg)
 
 	tests := []struct {
 		name string
@@ -597,7 +620,9 @@ func TestMapEncoder_elem_nonstring(t *testing.T) {
 }
 func TestMapEncoder_elem_ptrnonstring(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*int{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*int{}, cfg)
 
 	var (
 		one   = 1
@@ -648,7 +673,9 @@ func TestMapEncoder_elem_ptrnonstring(t *testing.T) {
 }
 func TestMapEncoder_elem_marshaltext(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]textStruct{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]textStruct{}, cfg)
 
 	tests := []struct {
 		name string
@@ -689,7 +716,9 @@ func TestMapEncoder_elem_marshaltext(t *testing.T) {
 
 func TestMapEncoder_elem_ptrmarshaltext(t *testing.T) {
 
-	enc := NewMapEncoder(map[string]*textStruct{})
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+	enc := NewMapEncoderWithConfig(map[string]*textStruct{}, cfg)
 
 	aa := &textStruct{[]byte("aa")}
 
@@ -747,6 +776,9 @@ type marshaler interface {
 
 func TestMapEncoder_sorted_nonstring(t *testing.T) {
 
+	cfg := DefaultConfig()
+	cfg.SetSortMapKeys(true)
+
 	tests := []struct {
 		name string
 		enc  marshaler
@@ -754,7 +786,7 @@ func TestMapEncoder_sorted_nonstring(t *testing.T) {
 	}{
 		{
 			"key: int",
-			NewMapEncoder(map[int]string{}),
+			NewMapEncoderWithConfig(map[int]string{}, cfg),
 			&map[int]string{
 				4:        "A",
 				59:       "B",
@@ -793,10 +825,7 @@ func TestMapEncoder_sorted_nonstring(t *testing.T) {
 
 func TestMapEncoder_unsorted_fast_string(t *testing.T) {
 
-	var cfg Config
-	cfg.SetSortMapKeys(false)
-
-	enc := NewMapEncoderWithConfig(map[string]string{}, cfg)
+	enc := NewMapEncoder(map[string]string{})
 
 	tests := []struct {
 		name string
@@ -842,10 +871,7 @@ func TestMapEncoder_unsorted_fast_string(t *testing.T) {
 
 func TestMapEncoder_unsorted_non_string(t *testing.T) {
 
-	var cfg Config
-	cfg.SetSortMapKeys(false)
-
-	enc := NewMapEncoderWithConfig(map[int]string{}, cfg)
+	enc := NewMapEncoder(map[int]string{})
 
 	tests := []struct {
 		name string

--- a/ptrconvert.go
+++ b/ptrconvert.go
@@ -88,6 +88,7 @@ func ptrFloat64ToBuf(v unsafe.Pointer, b *Buffer) {
 	b.Bytes = strconv.AppendFloat(b.Bytes, *(*float64)(v), 'f', -1, 64)
 }
 
+//go:nocheckptr
 func ptrStringToBuf(v unsafe.Pointer, b *Buffer) {
 	b.Write(*(*[]byte)(v))
 }

--- a/sliceencoder.go
+++ b/sliceencoder.go
@@ -17,6 +17,7 @@ type SliceEncoder struct {
 	instruction func(t unsafe.Pointer, w *Buffer)
 	tt          reflect.Type
 	offset      uintptr
+	cfg         Config
 }
 
 // Marshal executes the instruction set built up by NewSliceEncoder
@@ -33,7 +34,7 @@ func NewSliceEncoder(t interface{}) *SliceEncoder {
 
 // NewSliceEncoderWithConfig builds a new SliceEncoder using Config provided.
 func NewSliceEncoderWithConfig(t interface{}, cfg Config) *SliceEncoder {
-	e := &SliceEncoder{}
+	e := &SliceEncoder{cfg: cfg}
 
 	e.tt = reflect.TypeOf(t)
 	e.offset = e.tt.Elem().Size()
@@ -46,13 +47,13 @@ func NewSliceEncoderWithConfig(t interface{}, cfg Config) *SliceEncoder {
 	// what type of encoding do we need
 	switch e.tt.Elem().Kind() {
 	case reflect.Slice:
-		e.sliceInstr(cfg)
+		e.sliceInstr()
 
 	case reflect.Struct:
-		e.structInstr(cfg)
+		e.structInstr()
 
 	case reflect.Map:
-		e.mapInstr(cfg)
+		e.mapInstr()
 
 	case reflect.String:
 		e.stringInstr()
@@ -67,13 +68,13 @@ func NewSliceEncoderWithConfig(t interface{}, cfg Config) *SliceEncoder {
 
 		switch e.tt.Elem().Elem().Kind() {
 		case reflect.Slice:
-			e.ptrSliceInstr(cfg)
+			e.ptrSliceInstr()
 
 		case reflect.Struct:
-			e.ptrStrctInstr(cfg)
+			e.ptrStrctInstr()
 
 		case reflect.Map:
-			e.ptrMapInstr(cfg)
+			e.ptrMapInstr()
 
 		case reflect.String:
 			e.ptrStringInstr()
@@ -95,8 +96,8 @@ var (
 	zero = uintptr(0)
 )
 
-func (e *SliceEncoder) sliceInstr(cfg Config) {
-	enc := NewSliceEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), cfg)
+func (e *SliceEncoder) sliceInstr() {
+	enc := NewSliceEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 
@@ -113,8 +114,8 @@ func (e *SliceEncoder) sliceInstr(cfg Config) {
 	}
 }
 
-func (e *SliceEncoder) structInstr(cfg Config) {
-	enc := NewStructEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), cfg)
+func (e *SliceEncoder) structInstr() {
+	enc := NewStructEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 
@@ -131,8 +132,8 @@ func (e *SliceEncoder) structInstr(cfg Config) {
 	}
 }
 
-func (e *SliceEncoder) mapInstr(cfg Config) {
-	enc := NewMapEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), cfg)
+func (e *SliceEncoder) mapInstr() {
+	enc := NewMapEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 
@@ -215,8 +216,8 @@ func (e *SliceEncoder) timeInstr() {
 	}
 }
 
-func (e *SliceEncoder) ptrSliceInstr(cfg Config) {
-	enc := NewSliceEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Elem().Interface(), cfg)
+func (e *SliceEncoder) ptrSliceInstr() {
+	enc := NewSliceEncoderWithConfig(reflect.New(e.tt.Elem()).Elem().Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 
@@ -238,8 +239,8 @@ func (e *SliceEncoder) ptrSliceInstr(cfg Config) {
 	}
 }
 
-func (e *SliceEncoder) ptrStrctInstr(cfg Config) {
-	enc := NewStructEncoderWithConfig(reflect.New(e.tt.Elem().Elem()).Elem().Interface(), cfg)
+func (e *SliceEncoder) ptrStrctInstr() {
+	enc := NewStructEncoderWithConfig(reflect.New(e.tt.Elem().Elem()).Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 
@@ -261,8 +262,8 @@ func (e *SliceEncoder) ptrStrctInstr(cfg Config) {
 	}
 }
 
-func (e *SliceEncoder) ptrMapInstr(cfg Config) {
-	enc := NewMapEncoderWithConfig(reflect.New(e.tt.Elem().Elem()).Elem().Interface(), cfg)
+func (e *SliceEncoder) ptrMapInstr() {
+	enc := NewMapEncoderWithConfig(reflect.New(e.tt.Elem().Elem()).Elem().Interface(), e.cfg)
 	e.instruction = func(v unsafe.Pointer, w *Buffer) {
 		w.WriteByte('[')
 


### PR DESCRIPTION
Added support for map encoders, the change requires go1.12+ as the implementation is dependent on runtime functionality added in Go 1.12 (https://go-review.googlesource.com/c/go/+/33572).

Comparison benchmarks are available at: https://github.com/johngillott/gobenchmark/blob/master/README.md