### PR TITLE
added ,escape option which fixes #17 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ There are a couple of subtle ways you can configure the encoders.
 * It supports the same `json:"tag,options"` syntax as the stdlib, but not the same options. Currently the options you have are
     - `,stringer`, which instead of the standard serialization method for a given type, nominates that its `.String()` function is invoked instead to provide the serialization value.
     - `,raw`, which allows byteslice-like items (like `[]byte` and `string`) to be written to the buffer directly with no conversion, quoting or otherwise. `nil` or empty fields annotated as `raw` will output `null`. 
-    - `.encoder` which instead of the standard serialization method for a given type, nominates that its `.JSONEncode(*jingo.Buffer)` function is invoked instead. From there you can manually write to the buffer for that particular field. The interface you need to comply with is exported as `jingo.JSONEncoder`. 
+    - `,encoder` which instead of the standard serialization method for a given type, nominates that its `.JSONEncode(*jingo.Buffer)` function is invoked instead. From there you can manually write to the buffer for that particular field. The interface you need to comply with is exported as `jingo.JSONEncoder`. 
+    - `,escape`, which safely escapes `"` and `\` characters to valid JSON whilst writing. To get the same functionality when using `SliceEncoder` on its own, use `jingo.EscapeString` to initialize the encoder - e.g `NewSliceEncoder([]jingo.EscapeString)` - instead of `string` directly. There is obviously a performance impact on the write speed using this option, the benchmarks show it takes twice the time of a standard string write, so whilst it is still faster than using the stdlib, to get the best performance it is recommended to only be used when needed and only then when the escaping work can't be done up-front.
 
 ## How does it work
 

--- a/buffer.go
+++ b/buffer.go
@@ -25,9 +25,15 @@ func (b *Buffer) Write(v []byte) (int, error) {
 	return len(v), nil
 }
 
+// WriteString writes a string to the buffer
+func (b *Buffer) WriteString(v string) {
+	b.Bytes = append(b.Bytes, v...)
+}
+
 // WriteByte writes a single byte into the output buffer
-func (b *Buffer) WriteByte(v byte) {
+func (b *Buffer) WriteByte(v byte) error {
 	b.Bytes = append(b.Bytes, v)
+	return nil
 }
 
 // Reset allows this to be reused by emptying

--- a/ptrconvert.go
+++ b/ptrconvert.go
@@ -10,7 +10,11 @@ import (
 	"strconv"
 	"time"
 	"unsafe"
+
+	"fmt"
 )
+
+var _ = fmt.Sprint("")
 
 var typeconv = map[reflect.Kind]func(unsafe.Pointer, *Buffer){
 	reflect.Bool:    ptrBoolToBuf,
@@ -94,4 +98,26 @@ func ptrStringToBuf(v unsafe.Pointer, b *Buffer) {
 
 func ptrTimeToBuf(v unsafe.Pointer, b *Buffer) {
 	b.Bytes = (*time.Time)(v).AppendFormat(b.Bytes, time.RFC3339Nano)
+}
+
+func ptrEscapeStringToBuf(v unsafe.Pointer, w *Buffer) {
+	bs := *(*string)(v)
+
+	pos := 0
+	for i := 0; i < len(bs); i++ {
+		switch bs[i] {
+		case '\\', '"':
+			if pos < i {
+				w.WriteString(bs[pos:i])
+			}
+			pos = i + 1
+
+			w.WriteByte('\\')
+			w.WriteByte(bs[i])
+		}
+	}
+
+	if pos < len(bs) {
+		w.WriteString(bs[pos:])
+	}
 }

--- a/ptrconvert.go
+++ b/ptrconvert.go
@@ -10,11 +10,7 @@ import (
 	"strconv"
 	"time"
 	"unsafe"
-
-	"fmt"
 )
-
-var _ = fmt.Sprint("")
 
 var typeconv = map[reflect.Kind]func(unsafe.Pointer, *Buffer){
 	reflect.Bool:    ptrBoolToBuf,

--- a/structencoder.go
+++ b/structencoder.go
@@ -170,8 +170,8 @@ func (e *StructEncoder) optInstrEscape() {
 	if e.f.Type.Kind() == reflect.Slice {
 		e.flunk()
 
-		es := EscapeString("")
-		enc := NewSliceEncoder(&es)
+		/// create an escape string encoder internally instead of mirroring the struct, so people only need to pass the ,escape opt instead
+		enc := NewSliceEncoder([]EscapeString{})
 		f := e.f
 		e.instructions = append(e.instructions, func(v unsafe.Pointer, w *Buffer) {
 			var em interface{} = unsafe.Pointer(uintptr(v) + f.Offset)

--- a/structencoder.go
+++ b/structencoder.go
@@ -430,7 +430,7 @@ func (o tagOptions) Contains(optionName string) bool {
 var timeType = reflect.TypeOf(time.Time{})
 
 // EscapeString can be used to cast your string slice encoders in replacement of `[]string` when using SliceEncoder directly.
-// This is only necessary if you wish for the slice elements to be escaped of contorl sequences.
+// This is only necessary if you wish for the slice elements to be escaped of control sequences.
 // e.g var mySliceEncoder = NewSliceEncoder([]jingo.EscapeString{})
 // You can and should just use the `,escape` option on your struct fields when using StructEncoder.
 type EscapeString string


### PR DESCRIPTION
provides safety when serialising data with  \ and " in. 

New `EscapeString` type to help with the former when creating SliceEncoder directly - otherwise you can pass ,escape option on your struct fields. 

Fixed a lot of vet warnings that have started being raised around unsafe.Pointer since the last release. 

Added `WriteString` to buffer to support previous. 