### PR TITLE
[]byte is wider than string

### DIFF
--- a/ptrconvert.go
+++ b/ptrconvert.go
@@ -89,7 +89,7 @@ func ptrFloat64ToBuf(v unsafe.Pointer, b *Buffer) {
 }
 
 func ptrStringToBuf(v unsafe.Pointer, b *Buffer) {
-	b.Write(*(*[]byte)(v))
+	b.WriteString(*(*string)(v))
 }
 
 func ptrTimeToBuf(v unsafe.Pointer, b *Buffer) {

--- a/structencoder.go
+++ b/structencoder.go
@@ -114,8 +114,7 @@ func (e *StructEncoder) optInstrStringer() {
 		if !ok {
 			return
 		}
-		sr := e.String()
-		w.Write(*(*[]byte)(unsafe.Pointer(&sr)))
+		w.WriteString(e.String())
 	}
 
 	if e.f.Type.Kind() == reflect.Ptr {
@@ -151,12 +150,12 @@ func (e *StructEncoder) optInstrEncoder() {
 
 func (e *StructEncoder) optInstrRaw() {
 	conv := func(v unsafe.Pointer, w *Buffer) {
-		s := *(*[]byte)(v)
+		s := *(*string)(v)
 		if len(s) == 0 {
 			w.Write(null)
 			return
 		}
-		w.Write(s)
+		w.WriteString(s)
 	}
 
 	if e.f.Type.Kind() == reflect.Ptr {


### PR DESCRIPTION
Newer versions of -race correctly call us out for converting strings to []byte.

Though technically we are currently safe because we don't call `cap` we need to play nice with the race detector. 