### PR TITLE
fast paths for static chunk writes + string/int fields

### DIFF
--- a/jingo_test.go
+++ b/jingo_test.go
@@ -225,6 +225,83 @@ func BenchmarkUnicodeStdLib(b *testing.B) {
 	}
 }
 
+type UnicodeObjectLarge struct {
+	Chinese string `json:"chinese"`
+	Emoji   string `json:"emoji"`
+	Russian string `json:"russian"`
+	Test    string `json:"test"`
+	Test1   string `json:"test1"`
+	Test2   string `json:"test2"`
+	Test3   string `json:"test3"`
+}
+
+func Test_UnicodeLarge(t *testing.T) {
+	ub := UnicodeObjectLarge{
+		Chinese: "你好，世界",
+		Emoji:   "👋🌍😄😂👋💊🐂🍺",
+		Russian: "ру́сский язы́к",
+		Test:    "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test1:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test2:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test3:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+	}
+	// return
+
+	wantJSON := `{"chinese":"你好，世界","emoji":"👋🌍😄😂👋💊🐂🍺","russian":"ру́сский язы́к","test":"ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ","test1":"ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ","test2":"ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ","test3":"ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl "}`
+
+	var enc = NewStructEncoder(UnicodeObjectLarge{})
+	buf := NewBufferFromPool()
+	enc.Marshal(&ub, buf)
+	resultJSON := buf.String()
+
+	if !json.Valid(buf.Bytes) {
+		panic("not valid json")
+	}
+
+	if resultJSON != wantJSON {
+		t.Errorf("Test_UnicodeEncode Failed: want JSON:" + wantJSON + " got JSON:" + resultJSON)
+	}
+
+}
+
+func BenchmarkUnicodeLarge(b *testing.B) {
+	ub := UnicodeObjectLarge{
+		Chinese: "你好，世界",
+		Emoji:   "👋🌍😄😂👋💊🐂🍺",
+		Russian: "ру́сский язы́к",
+		Test:    "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test1:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test2:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test3:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+	}
+
+	var enc = NewStructEncoder(UnicodeObjectLarge{})
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		buf := NewBufferFromPool()
+		enc.Marshal(&ub, buf)
+		buf.ReturnToPool()
+	}
+}
+
+func BenchmarkUnicodeLargeStdLib(b *testing.B) {
+	ub := UnicodeObjectLarge{
+		Chinese: "你好，世界",
+		Emoji:   "👋🌍😄😂👋💊🐂🍺",
+		Russian: "ру́сский язы́к",
+		Test:    "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test1:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test2:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+		Test3:   "ascdjkl ascdhjklacdshlacdshjkl acdshjcdhjkl acdshjl kacdshjkl acdshjkacdshjklacdhjskl hjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjk lacdshjk acdshjkl acdshjkl hjkl acdshjkl acdshjkl acdshjkl cdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl acdshjkl ",
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		json.Marshal(&ub)
+	}
+}
+
 type TimeObject struct {
 	Time         time.Time    `json:"time"`
 	PtrTime      *time.Time   `json:"ptrTime"`


### PR DESCRIPTION
Added fast paths in the main loop for writing static data (e.g json fields), string fields and int fields (common types) to take advantage of inlining and less function call overhead. 

Best case, we can achieve 1/3 faster execution time than 1.0.2 e719a92 


Before
```
pkg: jingo                                                                                                           
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz                                                                        
BenchmarkUnicode-16                     16264910                66.14 ns/op            0 B/op          0 allocs/op   
BenchmarkUnicodeStdLib-16                3306157               358.5 ns/op           112 B/op          1 allocs/op   
BenchmarkUnicodeLarge-16                 7005199               153.0 ns/op             0 B/op          0 allocs/op  
BenchmarkUnicodeLargeStdLib-16            667453              1618 ns/op            1280 B/op          1 allocs/op
BenchmarkTime-16                         1302692               905.2 ns/op             0 B/op          0 allocs/op
BenchmarkTimeStdLib-16                    526065              2256 ns/op             336 B/op          5 allocs/op   
BenchmarkSlice-16                       19681183                58.90 ns/op            0 B/op          0 allocs/op   
BenchmarkSliceEscape-16                 10214242               119.3 ns/op             0 B/op          0 allocs/op
BenchmarkSliceStdLib-16                  3852097               307.3 ns/op            80 B/op          1 allocs/op   
BenchmarkJson-16                          400942              2808 ns/op               0 B/op          0 allocs/op   
BenchmarkStdJson-16                       104083             11516 ns/op            4866 B/op          1 allocs/op
BenchmarkSmallPayload-16                 7876168               149.5 ns/op             0 B/op          0 allocs/op   
BenchmarkSmallPayloadStdLib-16           2384288               506.1 ns/op           144 B/op          1 allocs/op   
BenchmarkLargePayload-16                  166273              6854 ns/op               0 B/op          0 allocs/op   
BenchmarkLargePayloadStdLib-16             70906             16632 ns/op            4867 B/op          1 allocs/op 
```

After
```
pkg: jingo
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkUnicode-16                     23073652                45.63 ns/op            0 B/op          0 allocs/op
BenchmarkUnicodeStdLib-16                3317107               354.9 ns/op           112 B/op          1 allocs/op
BenchmarkUnicodeLarge-16                10177656               113.6 ns/op             0 B/op          0 allocs/op
BenchmarkUnicodeLargeStdLib-16            699508              1596 ns/op            1280 B/op          1 allocs/op
BenchmarkTime-16                         1309560               867.4 ns/op             0 B/op          0 allocs/op
BenchmarkTimeStdLib-16                    536217              2255 ns/op             336 B/op          5 allocs/op
BenchmarkSlice-16                       20165407                57.17 ns/op            0 B/op          0 allocs/op
BenchmarkSliceEscape-16                 13210731                87.88 ns/op            0 B/op          0 allocs/op
BenchmarkSliceStdLib-16                  3839515               311.0 ns/op            80 B/op          1 allocs/op
BenchmarkJson-16                          428146              2692 ns/op               0 B/op          0 allocs/op
BenchmarkStdJson-16                       103767             11412 ns/op            4866 B/op          1 allocs/op
BenchmarkSmallPayload-16                10128330               111.7 ns/op             0 B/op          0 allocs/op
BenchmarkSmallPayloadStdLib-16           2373667               509.1 ns/op           144 B/op          1 allocs/op
BenchmarkLargePayload-16                  259286              4406 ns/op               0 B/op          0 allocs/op
BenchmarkLargePayloadStdLib-16             69682             16880 ns/op            4867 B/op          1 allocs/op
```