### PR TITLE
Quote time fields

### DIFF
--- a/jingo_test.go
+++ b/jingo_test.go
@@ -323,7 +323,7 @@ func Test_Time(t *testing.T) {
 		PtrSliceTime: []*time.Time{&d3},
 	}
 
-	wantJSON := `{"time":2000-09-17T20:04:26Z,"ptrTime":2001-09-17T20:04:26Z,"sliceTime":["2002-09-17T20:04:26Z"],"ptrSliceTime":["2003-09-17T20:04:26Z"]}`
+	wantJSON := `{"time":"2000-09-17T20:04:26Z","ptrTime":"2001-09-17T20:04:26Z","sliceTime":["2002-09-17T20:04:26Z"],"ptrSliceTime":["2003-09-17T20:04:26Z"]}`
 
 	var enc = NewStructEncoder(TimeObject{})
 

--- a/structencoder.go
+++ b/structencoder.go
@@ -118,9 +118,13 @@ func NewStructEncoder(t interface{}) *StructEncoder {
 
 		/// time is a type of struct, not a kind, so somewhat of a special case here.
 		case e.f.Type == timeType:
+			e.chunk(`"`)
 			e.val(ptrTimeToBuf)
+			e.chunk(`"`)
 		case e.f.Type.Kind() == reflect.Ptr && timeType == reflect.TypeOf(e.t).Field(e.i).Type.Elem():
+			e.chunk(`"`)
 			e.ptrval(ptrTimeToBuf)
+			e.chunk(`"`)
 
 		// write the value instruction depending on type
 		case e.f.Type.Kind() == reflect.Ptr:


### PR DESCRIPTION
After converting from standard json package to jingo I've noticed that time fields are encoded without quotes. So after encoding json to string using jingo my program is unable to read data back using either standard json package or gojay. This pull request adds back quotes for string fields.

This could be a breaking change for users who for whatever reason are ok with time encoded as string without quotes. 